### PR TITLE
Various fixups to get state res working

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Currently very experimental and PoC.
 
 ### To use:
 
+Requires node 20+
 ```
 yarn install
 yarn run start

--- a/shims/synapse/shim.py
+++ b/shims/synapse/shim.py
@@ -7,9 +7,8 @@ from typing import Collection, Dict, Iterable, List, Optional, Sequence, Set
 from pydantic import BaseModel
 from websockets.asyncio.server import serve
 
-
 from twisted.internet import defer
-from synapse.api.room_versions import RoomVersions
+from synapse.api.room_versions import RoomVersions, KNOWN_ROOM_VERSIONS
 from synapse.state.v2 import resolve_events_with_store
 from synapse.events import EventBase, make_event_from_dict
 
@@ -23,6 +22,10 @@ class WebSocketMessage(BaseModel):
 
 room_ver = RoomVersions.V10 # TODO: parameterise
 
+class FakeClock:
+    def sleep(self, msec: float) -> "defer.Deferred[None]":
+        return defer.succeed(None)
+
 class Connection:
     event_map: Dict[str, EventBase] = {}
 
@@ -31,9 +34,11 @@ class Connection:
         self.outstanding_requests = {}
 
 # Array<Record<StateKeyTuple, EventID>>
-    async def resolve_state(self, id: str, room_id: str, state):
-        print(f"resolve_state: {id}")
-        r = await resolve_events_with_store(FakeClock(),room_id, room_ver, state, event_map=None, state_res_store=self)
+    async def resolve_state(self, id: str, room_id: str, room_ver_str: str, state):
+        print(f"resolve_state: {id} in {room_id} on version {room_ver_str}")
+        if KNOWN_ROOM_VERSIONS.get(room_ver_str) is None:
+            print(f"  resolve_state: {id} WARNING: unknown room version {room_ver_str}")
+        r = await resolve_events_with_store(FakeClock(),room_id, KNOWN_ROOM_VERSIONS[room_ver_str], state, event_map=None, state_res_store=self)
         print(f"resolve_state: {id} responding")
         # convert tuple keys to strings
         r = {json.dumps(k):v for k,v in r.items()}
@@ -66,7 +71,7 @@ class Connection:
 
     async def get_events(
         self, event_ids: Collection[str], allow_rejected: bool = False
-    ) -> "defer.Deferred[Dict[str, EventBase]]":
+    ) -> Dict[str, EventBase]:
         """Get events from the database
 
         Args:
@@ -124,7 +129,7 @@ class Connection:
 
     async def get_auth_chain_difference(
         self, room_id: str, auth_sets: List[Set[str]]
-    ) -> "defer.Deferred[Set[str]]":
+    ) -> Set[str]:
         chains = [frozenset(await self._get_auth_chain(a)) for a in auth_sets]
         common = set(chains[0]).intersection(*chains[1:])
         return set(chains[0]).union(*chains[1:]) - common
@@ -145,21 +150,11 @@ async def handler(websocket):
                 # call get_event which needs more WS messages, so we cannot block the processing
                 # of incoming WS messages. When resolve_state concludes, it will send the response,
                 # hence why we pass in the id here so it can pair it up.
-                asyncio.create_task(c.resolve_state(wsm.id, wsm.data["room_id"], wsm.data["state"]))
+                asyncio.create_task(c.resolve_state(wsm.id, wsm.data["room_id"], wsm.data["room_version"], wsm.data["state"]))
             else:
                 print(f"unknown type: {wsm.type}")
         except Exception as err:
             print(f"recv error {err}")
-
-# Synapse specifics below
-# -----------------------
-
-class FakeClock:
-    def sleep(self, msec: float) -> "defer.Deferred[None]":
-        return defer.succeed(None)
-
-
-
 
 async def main():
     print("Listening on 0.0.0.0:1234")

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import * as d3 from "d3";
 import * as d3dag from "d3-dag";
 import JSON5 from "json5";
+import { StateAtEvent } from "./state_at_event";
 import {
     type DataGetEvent,
     type EventID,
@@ -9,7 +10,6 @@ import {
     StateResolver,
     StateResolverTransport,
 } from "./state_resolver";
-import { StateAtEvent } from "./state_at_event";
 
 const DEFAULT_ROOM_VERSION = "10";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,8 +31,7 @@ class Dag {
     startEventId: string;
     step: number;
     eventIdFileOrdering: string[];
-    eventIdWinners: Set<string>;
-    eventIdLosers: Set<string>;
+    eventIdPartOfState: Set<string>;
     renderEvents: Record<string, MatrixEvent>;
     scenario?: ScenarioFile;
 
@@ -50,8 +49,7 @@ class Dag {
         this.startEventId = "";
         this.step = 0;
         this.eventIdFileOrdering = [];
-        this.eventIdWinners = new Set();
-        this.eventIdLosers = new Set();
+        this.eventIdPartOfState = new Set();
         this.renderEvents = {};
     }
 
@@ -687,10 +685,7 @@ class Dag {
             .append("circle")
             .attr("r", nodeRadius)
             .attr("fill", (n) => {
-                if (this.eventIdLosers.has(n.id)) {
-                    return "red";
-                }
-                if (this.eventIdWinners.has(n.id)) {
+                if (this.eventIdPartOfState.has(n.id)) {
                     return "green";
                 }
                 return "black";
@@ -849,8 +844,7 @@ document.getElementById("resolve")!.addEventListener("click", async (ev) => {
                 }),
         );
         console.log("Resolved state:", r);
-        dag.eventIdLosers = new Set(r.lostEventIds);
-        dag.eventIdWinners = new Set(r.wonEventIds);
+        dag.eventIdPartOfState = new Set(r.eventIds);
     } catch (err) {
         console.error("failed to setup WS connection:", err);
     } finally {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import * as d3dag from "d3-dag";
 import JSON5 from "json5";
 import { type DataGetEvent, type MatrixEvent, StateResolver, StateResolverTransport } from "./state_resolver";
 
+const DEFAULT_ROOM_VERSION = "10";
+
 interface ScenarioFile {
     tardis_version: number;
     room_version: string;
@@ -32,6 +34,7 @@ class Dag {
     eventIdWinners: Set<string>;
     eventIdLosers: Set<string>;
     renderEvents: Record<string, MatrixEvent>;
+    scenario?: ScenarioFile;
 
     constructor() {
         this.cache = Object.create(null);
@@ -88,7 +91,8 @@ class Dag {
         if (Array.isArray(eventsOrScenario)) {
             scenario = {
                 tardis_version: 1,
-                room_version: "10",
+                room_version: DEFAULT_ROOM_VERSION,
+                room_id: eventsOrScenario[0].room_id,
                 calculate_event_ids: false,
                 events: eventsOrScenario,
             };
@@ -147,6 +151,7 @@ class Dag {
             }
         }
         this.maxDepth = maxDepth;
+        this.scenario = scenario;
     }
     setStepInterval(num: number) {
         this.stepInterval = num;
@@ -834,6 +839,7 @@ document.getElementById("resolve")!.addEventListener("click", async (ev) => {
     try {
         await transport.connect(resolver);
         const r = await resolver.resolveState(
+            dag.scenario ? dag.scenario.room_version : DEFAULT_ROOM_VERSION,
             Object.keys(dag.renderEvents)
                 .filter((eventId) => {
                     return dag.cache[eventId].state_key != null;

--- a/src/state_at_event.ts
+++ b/src/state_at_event.ts
@@ -1,0 +1,31 @@
+import type { EventID, StateKeyTuple } from "./state_resolver";
+
+export class StateAtEvent {
+    // private as we may want to do funny shenanigans later one e.g cache the result in indexeddb
+    private state: Record<EventID, Record<StateKeyTuple, EventID>>;
+
+    constructor() {
+        this.state = {};
+    }
+
+    setState(eventId: EventID, events: Record<StateKeyTuple, EventID>) {
+        this.state[eventId] = events;
+        console.log(`StateAtEvent ${eventId} is`, events);
+    }
+
+    getStateAsEventIds(eventId: EventID): Set<EventID> {
+        if (!this.state[eventId]) {
+            return new Set();
+        }
+        return new Set(Object.values(this.state[eventId]));
+    }
+
+    getState(eventId: EventID): Record<StateKeyTuple, EventID> {
+        if (!this.state[eventId]) {
+            return {};
+        }
+        return JSON.parse(JSON.stringify(this.state[eventId]));
+    }
+
+    // setResolver(func())
+}

--- a/src/state_resolver.test.ts
+++ b/src/state_resolver.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from "@jest/globals";
 import { type DataGetEvent, type DataResolveState, type MatrixEvent, StateResolver } from "./state_resolver";
 
+const roomVer = "custom";
+
 describe("StateResolver", () => {
     describe("resolveState", () => {
         const eventMap: Record<string, MatrixEvent> = {
@@ -54,12 +56,12 @@ describe("StateResolver", () => {
                     return eventMap[data.event_id];
                 },
             );
-            const promiseFoo = sr.resolveState([eventMap.$foo, eventMap.$foomember]);
+            const promiseFoo = sr.resolveState(roomVer, [eventMap.$foo, eventMap.$foomember]);
             let fooResolved = false;
             promiseFoo.then(() => {
                 fooResolved = true;
             });
-            const promiseBar = sr.resolveState([eventMap.$bar]);
+            const promiseBar = sr.resolveState(roomVer, [eventMap.$bar]);
             let barResolved = false;
             promiseBar.then(() => {
                 barResolved = true;
@@ -69,6 +71,7 @@ describe("StateResolver", () => {
             expect(fooRequest.id).toBeDefined();
             expect(fooRequest.data).toEqual({
                 room_id: "!foo",
+                room_version: roomVer,
                 // biome-ignore lint/complexity/useLiteralKeys: it reads much nicer in IDEs to use this form
                 state: [{ [`["m.room.create",""]`]: "$foo" }, { [`["m.room.member","@alice"]`]: "$foomember" }],
             });
@@ -76,6 +79,7 @@ describe("StateResolver", () => {
             expect(barRequest.id).toBeDefined();
             expect(barRequest.data).toEqual({
                 room_id: "!foo",
+                room_version: roomVer,
                 // biome-ignore lint/complexity/useLiteralKeys: it reads much nicer in IDEs to use this form
                 state: [{ [`["m.room.create",""]`]: "$bar" }],
             });
@@ -90,6 +94,7 @@ describe("StateResolver", () => {
                 // biome-ignore lint/complexity/useLiteralKeys: it reads much nicer in IDEs to use this form
                 result: { [`["m.room.create",""]`]: "$bar" },
                 room_id: "!foo",
+                room_version: roomVer,
             });
             const barResult = await promiseBar;
             expect(barResolved).toBe(true);
@@ -102,6 +107,7 @@ describe("StateResolver", () => {
                 // biome-ignore lint/complexity/useLiteralKeys: it reads much nicer in IDEs to use this form
                 result: { [`["m.room.create",""]`]: "$foo" },
                 room_id: "!foo",
+                room_version: roomVer,
             });
             const fooResult = await promiseFoo;
             expect(fooResolved).toBe(true);

--- a/src/state_resolver.test.ts
+++ b/src/state_resolver.test.ts
@@ -99,9 +99,8 @@ describe("StateResolver", () => {
             const barResult = await promiseBar;
             expect(barResolved).toBe(true);
             expect(fooResolved).toBe(false);
-            expect(barResult.wonEventIds).toEqual(["$bar"]);
+            expect(barResult.eventIds).toEqual(["$bar"]);
 
-            // drop the member event so it should be in the lost list.
             sr.onResolveStateResponse(fooRequest.id, {
                 state: [],
                 // biome-ignore lint/complexity/useLiteralKeys: it reads much nicer in IDEs to use this form
@@ -111,8 +110,7 @@ describe("StateResolver", () => {
             });
             const fooResult = await promiseFoo;
             expect(fooResolved).toBe(true);
-            expect(fooResult.wonEventIds).toEqual(["$foo"]);
-            expect(fooResult.lostEventIds).toEqual(["$foomember"]);
+            expect(fooResult.eventIds).toEqual(["$foo"]);
         });
     });
 });

--- a/src/state_resolver.ts
+++ b/src/state_resolver.ts
@@ -28,7 +28,7 @@ interface WebSocketMessage<T> {
 }
 
 type StateKeyTuple = string; // JSON encoded array of 2 string elements [type, state_key]
-type EventID = string;
+export type EventID = string;
 
 interface DataResolveState {
     room_id: string;
@@ -51,8 +51,7 @@ interface StateResolverSender {
 }
 
 interface ResolvedState {
-    wonEventIds: Array<string>;
-    lostEventIds: Array<string>;
+    eventIds: Array<string>;
 }
 
 class StateResolver implements StateResolverReceiver {
@@ -97,30 +96,12 @@ class StateResolver implements StateResolverReceiver {
             this.inflightRequests.set(id, (resolvedData: DataResolveState) => {
                 if (!resolvedData.result) {
                     resolve({
-                        wonEventIds: [],
-                        lostEventIds: [],
+                        eventIds: [],
                     });
                     return;
                 }
-                // map the won event IDs
-                const wonEventIds = new Set(
-                    Object.keys(resolvedData.result)
-                        .map((tuple: string): string => {
-                            return resolvedData.result![tuple] || "";
-                        })
-                        .values(),
-                );
-                // lost event IDs are IDs that were in the original request but not in the won list.
-                const lostEventIds = new Set<string>();
-                for (const eventId of initialSetOfEventIds) {
-                    if (wonEventIds.has(eventId)) {
-                        continue;
-                    }
-                    lostEventIds.add(eventId);
-                }
                 resolve({
-                    wonEventIds: Array.from(wonEventIds),
-                    lostEventIds: Array.from(lostEventIds),
+                    eventIds: Array.from(Object.values(resolvedData.result)),
                 });
             });
             this.sender.sendResolveState(id, {

--- a/src/state_resolver.ts
+++ b/src/state_resolver.ts
@@ -32,6 +32,7 @@ type EventID = string;
 
 interface DataResolveState {
     room_id: string;
+    room_version: string;
     state: Array<Record<StateKeyTuple, EventID>>;
     result?: Record<StateKeyTuple, EventID>;
 }
@@ -77,7 +78,7 @@ class StateResolver implements StateResolverReceiver {
         this.inflightRequests.delete(id);
     }
 
-    async resolveState(stateEvents: Array<MatrixEvent>): Promise<ResolvedState> {
+    async resolveState(roomVersion: string, stateEvents: Array<MatrixEvent>): Promise<ResolvedState> {
         // convert events into a form suitable for sending over the wire
         const state: Array<Record<StateKeyTuple, EventID>> = [];
         const initialSetOfEventIds = new Set<string>();
@@ -125,6 +126,7 @@ class StateResolver implements StateResolverReceiver {
             this.sender.sendResolveState(id, {
                 state: state,
                 room_id: roomId,
+                room_version: roomVersion,
             });
         });
 


### PR DESCRIPTION
Fixed bugs:
 - tuples weren't being decoded in the shim (surprised this worked at all!)
 - allow room version to be sent to the shim

Changed semantics:
 - drop win/lose logic as I was driving resolve_state incorrectly.
 - Iteratively perform state res and store the state at each event, this was the bit I was missing before.

This now does appear to be able to repro some state resets.