### PR TITLE
Refactor things out of index.ts

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,4 +1,13 @@
-import type { EventID, StateKeyTuple } from "./state_resolver";
+import type { EventID, MatrixEvent, StateKeyTuple } from "./state_resolver";
+
+export class Cache {
+    stateAtEvent: StateAtEvent;
+    eventCache: EventCache;
+    constructor() {
+        this.stateAtEvent = new StateAtEvent();
+        this.eventCache = new EventCache();
+    }
+}
 
 export class StateAtEvent {
     // private as we may want to do funny shenanigans later one e.g cache the result in indexeddb
@@ -26,6 +35,18 @@ export class StateAtEvent {
         }
         return JSON.parse(JSON.stringify(this.state[eventId]));
     }
+}
 
-    // setResolver(func())
+export class EventCache {
+    cache: Map<string, MatrixEvent>;
+    constructor() {
+        // in-memory for now, but could be stored in idb or elsewhere.
+        this.cache = new Map<string, MatrixEvent>();
+    }
+    store(ev: MatrixEvent) {
+        this.cache.set(ev.event_id, ev);
+    }
+    get(eventId: string): MatrixEvent | undefined {
+        return this.cache.get(eventId);
+    }
 }

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -1,0 +1,38 @@
+import type { Scenario } from "./scenario";
+
+// Debugger provides a mechanism for stepping through a scenario, exposing UI elements and calling out to resolve state.
+export class Debugger {
+    private index: number;
+    private eventIdOrdering: string[];
+    private currentEventId: string;
+
+    constructor(readonly scenario: Scenario) {
+        this.index = -1; // so when you hit next() we load to the first event.
+        this.eventIdOrdering = scenario.events.map((ev) => ev.event_id);
+    }
+
+    next() {
+        this.index++;
+        if (this.index >= this.eventIdOrdering.length) {
+            this.index = this.eventIdOrdering.length - 1;
+        }
+        this.currentEventId = this.eventIdOrdering[this.index];
+    }
+    previous() {
+        this.index--;
+        if (this.index < 0) {
+            this.index = 0;
+        }
+        this.currentEventId = this.eventIdOrdering[this.index];
+    }
+    current(): string {
+        return this.currentEventId;
+    }
+    eventsUpToCurrent(): string[] {
+        const eventIds: string[] = [];
+        for (let i = 0; i <= this.index; i++) {
+            eventIds.push(this.eventIdOrdering[i]);
+        }
+        return eventIds;
+    }
+}

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -1,5 +1,5 @@
-import type { Scenario } from "./scenario";
 import type { Cache } from "./cache";
+import type { Scenario } from "./scenario";
 import type { EventID, StateKeyTuple } from "./state_resolver";
 
 // Debugger provides a mechanism for stepping through a scenario, exposing UI elements and calling out to resolve state.

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -1,4 +1,6 @@
 import type { Scenario } from "./scenario";
+import type { Cache } from "./cache";
+import type { EventID, StateKeyTuple } from "./state_resolver";
 
 // Debugger provides a mechanism for stepping through a scenario, exposing UI elements and calling out to resolve state.
 export class Debugger {
@@ -34,5 +36,57 @@ export class Debugger {
             eventIds.push(this.eventIdOrdering[i]);
         }
         return eventIds;
+    }
+
+    async resolve(
+        cache: Cache,
+        resolveState: (
+            roomId: string,
+            roomVer: string,
+            states: Array<Record<StateKeyTuple, EventID>>,
+        ) => Promise<Record<StateKeyTuple, EventID>>,
+    ): Promise<void> {
+        const atEventId = this.current();
+        const atEvent = cache.eventCache.get(atEventId)!;
+        let theState: Record<StateKeyTuple, EventID> = {};
+        switch (atEvent.prev_events.length) {
+            case 0: // e.g m.room.create
+                // do nothing, as we default to empty prev states.
+                // we'll add the create event now.
+                break;
+            case 1: {
+                // linear: the state is what came before plus this
+                const prevEventId = atEvent.prev_events[0];
+                const prevState = cache.stateAtEvent.getState(prevEventId);
+                if (Object.keys(prevState).length === 0) {
+                    console.error(
+                        `WARN: we do not know the state at ${prevEventId} yet, so the state calculation for ${atEventId} may be wrong!`,
+                    );
+                }
+                theState = prevState;
+                break;
+            }
+            default: {
+                // we need to do state resolution.
+                const states: Array<Record<StateKeyTuple, EventID>> = [];
+                for (const prevEventId of atEvent.prev_events) {
+                    const prevState = cache.stateAtEvent.getState(prevEventId);
+                    if (Object.keys(prevState).length === 0) {
+                        console.error(
+                            `WARN: we do not know the state at ${prevEventId} yet, so the state calculation for ${atEventId} may be wrong!`,
+                        );
+                    }
+                    states.push(prevState);
+                }
+                console.log("performing state resolution for prev_events:", atEvent.prev_events);
+                theState = await resolveState(atEvent.room_id, this.scenario.roomVersion, states);
+            }
+        }
+        // include this state event
+        if (atEvent.state_key != null) {
+            theState[JSON.stringify([atEvent.type, atEvent.state_key])] = atEventId;
+        }
+
+        cache.stateAtEvent.setState(atEventId, theState);
     }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -736,56 +736,25 @@ document.getElementById("stepbwd")!.addEventListener("click", async (ev) => {
     dag.refresh();
 });
 document.getElementById("resolve")!.addEventListener("click", async (ev) => {
-    const atEventId = dag.debugger.current();
-    const atEvent = dag.cache.eventCache.get(atEventId)!;
-    let theState: Record<StateKeyTuple, EventID> = {};
-    switch (atEvent.prev_events.length) {
-        case 0: // e.g m.room.create
-            // do nothing, as we default to empty prev states.
-            // we'll add the create event now.
-            break;
-        case 1: {
-            // linear: the state is what came before plus this
-            const prevEventId = atEvent.prev_events[0];
-            const prevState = dag.cache.stateAtEvent.getState(prevEventId);
-            if (Object.keys(prevState).length === 0) {
-                console.error(
-                    `WARN: we do not know the state at ${prevEventId} yet, so the state calculation for ${atEventId} may be wrong!`,
-                );
-            }
-            theState = prevState;
-            break;
-        }
-        default: {
-            // we need to do state resolution.
-            const states: Array<Record<StateKeyTuple, EventID>> = [];
-            for (const prevEventId of atEvent.prev_events) {
-                const prevState = dag.cache.stateAtEvent.getState(prevEventId);
-                if (Object.keys(prevState).length === 0) {
-                    console.error(
-                        `WARN: we do not know the state at ${prevEventId} yet, so the state calculation for ${atEventId} may be wrong!`,
-                    );
-                }
-                states.push(prevState);
-            }
-            console.log("performing state resolution for prev_events:", atEvent.prev_events);
+    await dag.debugger.resolve(
+        dag.cache,
+        async (
+            roomId: string,
+            roomVer: string,
+            states: Array<Record<StateKeyTuple, EventID>>,
+        ): Promise<Record<StateKeyTuple, EventID>> => {
             try {
                 await transport.connect(resolver);
-                const r = await resolver.resolveState(atEvent.room_id, dag.scenario!.roomVersion, states);
-                theState = r.state;
+                const r = await resolver.resolveState(roomId, roomVer, states);
+                return r.state;
             } catch (err) {
                 console.error("failed to setup WS connection:", err);
             } finally {
                 transport.close();
             }
-        }
-    }
-    // include this state event
-    if (atEvent.state_key != null) {
-        theState[JSON.stringify([atEvent.type, atEvent.state_key])] = atEventId;
-    }
-
-    dag.cache.stateAtEvent.setState(atEventId, theState);
+            return {};
+        },
+    );
     dag.refresh();
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import * as d3 from "d3";
 import * as d3dag from "d3-dag";
 import { Cache } from "./cache";
+import { Debugger } from "./debugger";
+import { type Scenario, loadScenarioFromFile } from "./scenario";
 import {
     type DataGetEvent,
     type EventID,
@@ -9,8 +11,6 @@ import {
     StateResolver,
     StateResolverTransport,
 } from "./state_resolver";
-import { loadScenarioFromFile, type Scenario } from "./scenario";
-import { Debugger } from "./debugger";
 
 interface Link {
     auth: boolean;

--- a/src/scenario.ts
+++ b/src/scenario.ts
@@ -1,0 +1,115 @@
+import JSON5 from "json5";
+import type { MatrixEvent } from "./state_resolver";
+
+export const DEFAULT_ROOM_VERSION = "10";
+
+// ScenarioFile is the file format of .json5 files used with tardis.
+export interface ScenarioFile {
+    // Required. The version of the file, always '1'.
+    tardis_version: number;
+    // Required. The events in this scenario, in the order they should be processed (typically topologically sorted)
+    events: Array<MatrixEvent>;
+    // Optional. The room version these events are represented in. Default: DEFAULT_ROOM_VERSION.
+    room_version: string;
+    // Optional. If events are missing a room_id key, populate it from this field. For brevity.
+    room_id: string;
+    // Optional. If true, calculates the event_id field.
+    calculate_event_ids: boolean;
+}
+
+// Scenario is a loaded scenario for use with tardis. ScenarioFiles end up being represented as Scenarios.
+export interface Scenario {
+    // The events in this scenario, in the order they should be processed (typically topologically sorted).
+    events: Array<MatrixEvent>;
+    // The room version for these events
+    roomVersion: string;
+}
+
+// loadScenarioFromFile loads a scenario file (.json5) or new-line delimited JSON, which represents the events in the scenario, in the order they should be processed.
+// Throws if there is malformed events or malformed data. Requires `globalThis.gmslEventIDForEvent` to exist (loaded via gmsl.wasm).
+export async function loadScenarioFromFile(f: File): Promise<Scenario> {
+    // read the file
+    const eventsOrScenario = await new Promise(
+        (resolve: (value: Array<MatrixEvent> | ScenarioFile) => void, reject) => {
+            const reader = new FileReader();
+            reader.onload = (data) => {
+                if (!data.target || !data.target.result) {
+                    return;
+                }
+                if (f.name.endsWith(".json5")) {
+                    // scenario file
+                    resolve(JSON5.parse(data.target.result as string) as ScenarioFile);
+                    return;
+                }
+                const contents = (data.target.result as string)
+                    .split("\n")
+                    .filter((line) => {
+                        return line.trim().length > 0;
+                    })
+                    .map((line) => {
+                        const j = JSON.parse(line);
+                        return j;
+                    });
+                resolve(contents as Array<MatrixEvent>);
+            };
+            reader.readAsText(f);
+        },
+    );
+    // work out which file format we're dealing with and make a scenario file
+    let scenarioFile: ScenarioFile;
+    if (Array.isArray(eventsOrScenario)) {
+        scenarioFile = {
+            tardis_version: 1,
+            room_version: DEFAULT_ROOM_VERSION,
+            room_id: eventsOrScenario[0].room_id,
+            calculate_event_ids: false,
+            events: eventsOrScenario,
+        };
+    } else {
+        // it's a test scenario
+        scenarioFile = eventsOrScenario;
+    }
+    const scenario: Scenario = {
+        events: [],
+        roomVersion: scenarioFile.room_version,
+    };
+    // validate and preprocess the scenario file into a valid scenario
+    const fakeEventIdToRealEventId = new Map<string, string>();
+    for (const ev of scenarioFile.events) {
+        if (!ev) {
+            throw new Error("missing event");
+        }
+        if (!ev.event_id) {
+            throw new Error(`event is missing 'event_id', got ${JSON.stringify(ev)}`);
+        }
+        if (!ev.type) {
+            throw new Error(`event is missing 'type' field, got ${JSON.stringify(ev)}`);
+        }
+        if (!ev.depth) {
+            throw new Error(`event is missing 'depth' field, got ${JSON.stringify(ev)}`);
+        }
+        if (!ev.room_id && scenarioFile.room_id) {
+            ev.room_id = scenarioFile.room_id;
+        }
+        if (scenarioFile.calculate_event_ids) {
+            const realEventId = globalThis.gmslEventIDForEvent(JSON.stringify(ev), scenarioFile.room_version);
+            fakeEventIdToRealEventId.set(ev.event_id, realEventId);
+            ev.event_id = realEventId;
+            // also replace any references in prev_events and auth_events
+            for (const key of ["prev_events", "auth_events"]) {
+                const replacement: Array<string> = [];
+                for (const fakeEventId of ev[key]) {
+                    const realEventId = fakeEventIdToRealEventId.get(fakeEventId);
+                    if (realEventId) {
+                        replacement.push(realEventId);
+                    } else {
+                        replacement.push(fakeEventId);
+                    }
+                }
+                ev[key] = replacement;
+            }
+        }
+        scenario.events.push(ev);
+    }
+    return scenario;
+}


### PR DESCRIPTION
Removes around 20% lines from index.ts (200 or so lines). Group functionality together coherently.

Critically, this automatically resolves earlier states so you don't need to click "resolve state" at every step..