### PR TITLE
Support precalculated_state_after

### DIFF
--- a/examples/auth-basic.json5
+++ b/examples/auth-basic.json5
@@ -16,6 +16,9 @@
             "$BOB_KICK": "Bob is kicked by Kegan."
         }
     },
+    "precalculated_state_after": {
+        "$BOB_JOIN": ["$CREATE", "$PL"]
+    },
     "events": [
         {
             "event_id": "$CREATE",

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,22 @@ class Dag {
                 this.createEventId = ev.event_id;
             }
         }
+        if (scenario.precalculatedStateAfter) {
+            for (const preCalcEventId in scenario.precalculatedStateAfter) {
+                const stateMap: Record<StateKeyTuple, EventID> = {};
+                for (const stateEventId of scenario.precalculatedStateAfter[preCalcEventId]) {
+                    const stateEvent = this.cache.eventCache.get(stateEventId);
+                    if (!stateEvent || stateEvent.state_key == null) {
+                        console.log(
+                            `precalculated_state_after for ${preCalcEventId} includes ${stateEventId} but it isn't a state event we know about. Skipping.`,
+                        );
+                        continue;
+                    }
+                    stateMap[JSON.stringify([stateEvent.type, stateEvent.state_key])] = stateEvent.event_id;
+                }
+                this.cache.stateAtEvent.setState(preCalcEventId, stateMap);
+            }
+        }
         this.scenario = scenario;
         this.debugger = new Debugger(scenario);
         eventList.clear();


### PR DESCRIPTION
So we can test some weird edge cases around `/state_ids` responses. And so we can have examples which don't need a shim (since we've precalculated the state resolved response already and put it into the file!)