### PR TITLE
balance 2-way forks

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -182,7 +182,8 @@ const redraw = (vis: HTMLDivElement, events: MatrixEvent[]) => {
         }
         edges.sort((a, b) => a.x - b.x);
         d.laneWidth = edges.at(-1)?.x;
-        if (d.laneWidth % 2) { // balance simple 2-way forks
+        if (d.laneWidth % 2) {
+            // balance simple 2-way forks
             d.x -= 0.5;
             d.laneWidth -= 0.5;
         }

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -169,17 +169,23 @@ const redraw = (vis: HTMLDivElement, events: MatrixEvent[]) => {
 
     // another pass to figure out the right-hand edge
     const edges: Array<{ x: number; y: number }> = [];
-    for (let i = 0; i < data.length; i++) {
+    data[0].laneWidth = 0;
+    for (let i = 1; i < data.length; i++) {
+        const p = data[i - 1];
         const d = data[i];
         while (edges.length > 0 && i > edges.at(-1)?.y) edges.pop();
-        if (d.next_events) {
+        if (p.next_events) {
             edges.push({
-                x: eventsById.get(d.next_events.at(-1)).x,
-                y: eventsById.get(d.next_events.at(-1)).y,
+                x: eventsById.get(p.next_events.at(-1)).x,
+                y: eventsById.get(p.next_events.at(-1)).y,
             });
         }
         edges.sort((a, b) => a.x - b.x);
         d.laneWidth = edges.at(-1)?.x;
+        if (d.laneWidth % 2) { // balance simple 2-way forks
+            d.x -= 0.5;
+            d.laneWidth -= 0.5;
+        }
     }
 
     const margin = {

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -167,6 +167,8 @@ const redraw = (vis: HTMLDivElement, events: MatrixEvent[]) => {
         }
     }
 
+    const balanceTwoWayForks = true;
+
     // another pass to figure out the right-hand edge
     const edges: Array<{ x: number; y: number }> = [];
     data[0].laneWidth = 0;
@@ -182,7 +184,7 @@ const redraw = (vis: HTMLDivElement, events: MatrixEvent[]) => {
         }
         edges.sort((a, b) => a.x - b.x);
         d.laneWidth = edges.at(-1)?.x;
-        if (d.laneWidth % 2) {
+        if (balanceTwoWayForks && d.laneWidth % 2) {
             // balance simple 2-way forks
             d.x -= 0.5;
             d.laneWidth -= 0.5;


### PR DESCRIPTION
so that for trivial 2-way forks, the children are balanced evenly under the parent. hopefully this won't mess up more complex layouts too badly; if it does, you can always turn it off.

it also fixes an off-by-one in calculating the labels on the RHS edge.