### PR TITLE
Improve loading performance

### DIFF
--- a/src/event_list.ts
+++ b/src/event_list.ts
@@ -4,6 +4,7 @@ export class EventList {
     private highlightedEventId: string;
     private positionListener: (eventId: string) => void;
     private jsonListener: (eventId: string) => void;
+    private tempList: DocumentFragment = document.createDocumentFragment();
     constructor(
         readonly container: HTMLElement,
         readonly template: HTMLTemplateElement,
@@ -11,6 +12,7 @@ export class EventList {
 
     clear(): void {
         this.container.innerHTML = "";
+        this.tempList = document.createDocumentFragment();
     }
 
     onEventClick(fn): void {
@@ -53,7 +55,11 @@ export class EventList {
         if (ev.state_key != null) {
             row.style.fontWeight = "600";
         }
-        this.container.appendChild(row);
+        this.tempList.appendChild(row);
+    }
+
+    render() {
+        this.container.appendChild(this.tempList);
     }
 
     highlight(eventId: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -94,6 +94,7 @@ class Dag {
         scenario.events.forEach((ev, i) => {
             eventList.appendEvent(i, ev);
         });
+        eventList.render();
         eventList.highlight(this.debugger.current());
         eventList.onEventClick((eventId: string) => {
             this.debugger.goTo(eventId);


### PR DESCRIPTION
First of all a disclaimer that all tests and profiles had been done with Chromium "Version 131.0.6778.204 (Offizieller Build) Fedora Project (64-Bit)" and not firefox.

The before profile has been done using https://matrix-org.github.io/tardis/ and the after using a debug build.

Before the changes the redraw method on my pc took ~`22802.8ms`. After the changes I am getting ~`9583.5ms`.  This is rougly an improvement of 58%

There only was a visual comparison on correctness however. I strongly think there have been no changes in behaviour of the code however I sugest having a good read :)

The profiles and the file used for testing can be found here https://cloud.midnightthoughts.space/s/yWfniCMFZ7xA99w (size limit of github exceeded. Its my nextcloud)