### PR TITLE
Prevent the placeholders to end up on the graph line making them unreadable

### DIFF
--- a/src/graph.ts
+++ b/src/graph.ts
@@ -604,7 +604,7 @@ const redraw = (vis: HTMLDivElement, events: MatrixEvent[], opts: RenderOptions)
     const textOffset = (d) =>
         opts.showAuthChain || opts.showAuthDAG
             ? maxAuthLaneStart * gx + (maxAuthLane - maxAuthLaneStart) * agx
-            : d.laneWidth * gx;
+            : (d.laneWidth ?? 0) * gx;
 
     // Add event IDs on the right side
     node.append("text")


### PR DESCRIPTION
Without this the `laneWidth` might be `undefined` leading to `textOffset` being `NaN` which causes a d3 error and the placeholders not being properly aligned horizontally when none of the authChain or AuthDAG options are ticked.

## Before
![grafik](https://github.com/user-attachments/assets/289f3ae1-aea4-40df-b939-4cce724d55a4)


## After
![grafik](https://github.com/user-attachments/assets/369e02ec-3fd7-47bc-aef8-9f3fc340a9db)

(Dont mind the graph being misrendered. That seems to be chromium misbehaving due to the svg size. Firefox seems to render it somewhat better)